### PR TITLE
add 4k max dimensions support for KnnVector

### DIFF
--- a/src/main/java/io/neusearch/lucene/store/s3/codec/KnnVectorsFormatMaxDimExt.java
+++ b/src/main/java/io/neusearch/lucene/store/s3/codec/KnnVectorsFormatMaxDimExt.java
@@ -1,0 +1,36 @@
+package io.neusearch.lucene.store.s3.codec;
+
+import org.apache.lucene.codecs.KnnVectorsFormat;
+import org.apache.lucene.codecs.KnnVectorsReader;
+import org.apache.lucene.codecs.KnnVectorsWriter;
+import org.apache.lucene.index.SegmentReadState;
+import org.apache.lucene.index.SegmentWriteState;
+
+import java.io.IOException;
+
+public class KnnVectorsFormatMaxDimExt extends KnnVectorsFormat {
+
+    private static final short MAX_DIMS_COUNT = 4096;
+
+    private final KnnVectorsFormat delegate;
+
+    public KnnVectorsFormatMaxDimExt(KnnVectorsFormat delegate) {
+        super(delegate.getName());
+        this.delegate = delegate;
+    }
+
+    @Override
+    public KnnVectorsWriter fieldsWriter(SegmentWriteState state) throws IOException {
+        return delegate.fieldsWriter(state);
+    }
+
+    @Override
+    public KnnVectorsReader fieldsReader(SegmentReadState state) throws IOException {
+        return delegate.fieldsReader(state);
+    }
+
+    @Override
+    public int getMaxDimensions(String fieldName) {
+        return MAX_DIMS_COUNT;
+    }
+}


### PR DESCRIPTION
IndexWriterConfig iwc = new IndexWriterConfig(new StandardAnalyzer());

iwc.setCodec(
                new Lucene95Codec() {
                    @Override
                    public KnnVectorsFormat getKnnVectorsFormatForField(String field) {
                        return new KnnVectorsFormatMaxDimExt(new Lucene95HnswVectorsFormat());
                    }
                });